### PR TITLE
Rename argv propery to args

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It is exceedingly difficult to provide an API which would both be friendly to th
 - [🙌 Contributing](#-contributing)
 - [💡 `process.mainArgs` Proposal](#-processmainargs-proposal)
   - [Implementation:](#implementation)
-- [💡 `util.parseArgs(argv)` Proposal](#-utilparseargsargv-proposal)
+- [💡 `util.parseArgs([config])` Proposal](#-utilparseargsconfig-proposal)
 - [📃 Examples](#-examples)
   - [F.A.Qs](#faqs)
 
@@ -78,12 +78,12 @@ process.mainArgs = process.argv.slice(process._exec ? 1 : 2)
 
 * `config` {Object} (Optional) The `config` parameter is an
   object supporting the following properties:
-  * `argv` {string[]} (Optional) Array of argument strings; defaults
+  * `args` {string[]} (Optional) Array of argument strings; defaults
     to [`process.mainArgs`](process_argv)
-  * `options` {Object} (Optional) An object describing the known options to look for in `argv`; `options` keys are the long names of the known options, and the values are objects with the following properties:
+  * `options` {Object} (Optional) An object describing the known options to look for in `args`; `options` keys are the long names of the known options, and the values are objects with the following properties:
     * `type` {'string'|'boolean'} (Optional) Type of known option; defaults to `'boolean'`; 
-    * `multiples` {boolean} (Optional) If true, when appearing one or more times in `argv`, results are collected in an `Array`
-    * `short` {string} (Optional) A single character alias for an option; When appearing one or more times in `argv`; Respects the `multiples` configuration
+    * `multiples` {boolean} (Optional) If true, when appearing one or more times in `args`, results are collected in an `Array`
+    * `short` {string} (Optional) A single character alias for an option; When appearing one or more times in `args`; Respects the `multiples` configuration
   * `strict` {Boolean} (Optional) A `Boolean` on wheather or not to throw an error when unknown args are encountered
 * Returns: {Object} An object having properties:
   * `flags` {Object}, having properties and `Boolean` values corresponding to parsed options passed
@@ -101,9 +101,9 @@ const { parseArgs } = require('@pkgjs/parseargs');
 ```js
 // unconfigured
 const { parseArgs } = require('@pkgjs/parseargs');
-const argv = ['-f', '--foo=a', '--bar', 'b'];
+const args = ['-f', '--foo=a', '--bar', 'b'];
 const options = {};
-const { flags, values, positionals } = parseArgs({ argv, options });
+const { flags, values, positionals } = parseArgs({ args, options });
 // flags = { f: true, bar: true }
 // values = { foo: 'a' }
 // positionals = ['b']
@@ -112,13 +112,13 @@ const { flags, values, positionals } = parseArgs({ argv, options });
 ```js
 const { parseArgs } = require('@pkgjs/parseargs');
 // withValue
-const argv = ['-f', '--foo=a', '--bar', 'b'];
+const args = ['-f', '--foo=a', '--bar', 'b'];
 const options = {
   foo: {
     type: 'string',
   },
 };
-const { flags, values, positionals } = parseArgs({ argv, options });
+const { flags, values, positionals } = parseArgs({ args, options });
 // flags = { f: true }
 // values = { foo: 'a', bar: 'b' }
 // positionals = []
@@ -127,14 +127,14 @@ const { flags, values, positionals } = parseArgs({ argv, options });
 ```js
 const { parseArgs } = require('@pkgjs/parseargs');
 // withValue & multiples
-const argv = ['-f', '--foo=a', '--foo', 'b'];
+const args = ['-f', '--foo=a', '--foo', 'b'];
 const options = {
   foo: {
     type: 'string',
     multiples: true,
   },
 };
-const { flags, values, positionals } = parseArgs({ argv, options });
+const { flags, values, positionals } = parseArgs({ args, options });
 // flags = { f: true }
 // values = { foo: ['a', 'b'] }
 // positionals = []
@@ -143,13 +143,13 @@ const { flags, values, positionals } = parseArgs({ argv, options });
 ```js
 const { parseArgs } = require('@pkgjs/parseargs');
 // shorts
-const argv = ['-f', 'b'];
+const args = ['-f', 'b'];
 const options = {
   foo: {
     short: 'f',
   },
 };
-const { flags, values, positionals } = parseArgs({ argv, options });
+const { flags, values, positionals } = parseArgs({ args, options });
 // flags = { foo: true }
 // values = {}
 // positionals = ['b']

--- a/index.js
+++ b/index.js
@@ -80,10 +80,10 @@ function storeOptionValue(options, option, value, result) {
 }
 
 const parseArgs = ({
-  argv = getMainArgs(),
+  args = getMainArgs(),
   options = {}
 } = {}) => {
-  validateArray(argv, 'argv');
+  validateArray(args, 'args');
   validateObject(options, 'options');
   for (const [option, optionConfig] of ObjectEntries(options)) {
     validateObject(optionConfig, `options.${option}`);
@@ -108,8 +108,8 @@ const parseArgs = ({
   };
 
   let pos = 0;
-  while (pos < argv.length) {
-    let arg = argv[pos];
+  while (pos < args.length) {
+    let arg = args[pos];
 
     if (StringPrototypeStartsWith(arg, '-')) {
       if (arg === '-') {
@@ -122,7 +122,7 @@ const parseArgs = ({
         // and is returned verbatim
         result.positionals = ArrayPrototypeConcat(
           result.positionals,
-          ArrayPrototypeSlice(argv, ++pos)
+          ArrayPrototypeSlice(args, ++pos)
         );
         return result;
       } else if (StringPrototypeCharAt(arg, 1) !== '-') {
@@ -132,7 +132,7 @@ const parseArgs = ({
             const short = StringPrototypeCharAt(arg, i);
             // Add 'i' to 'pos' such that short options are parsed in order
             // of definition:
-            ArrayPrototypeSplice(argv, pos + (i - 1), 0, `-${short}`);
+            ArrayPrototypeSplice(args, pos + (i - 1), 0, `-${short}`);
           }
         }
 
@@ -159,8 +159,8 @@ const parseArgs = ({
           StringPrototypeSlice(arg, 0, index),
           StringPrototypeSlice(arg, index + 1),
           result);
-      } else if (pos + 1 < argv.length &&
-        !StringPrototypeStartsWith(argv[pos + 1], '-')
+      } else if (pos + 1 < args.length &&
+        !StringPrototypeStartsWith(args[pos + 1], '-')
       ) {
         // `type: "string"` option should also support setting values when '='
         // isn't used ie. both --foo=b and --foo b should work
@@ -170,7 +170,7 @@ const parseArgs = ({
         // arg, else set value as undefined ie. --foo b --bar c, after setting
         // b as the value for foo, evaluate --bar next and skip 'b'
         const val = options[arg] && options[arg].type === 'string' ?
-          argv[++pos] :
+          args[++pos] :
           undefined;
         storeOptionValue(options, arg, val, result);
       } else {

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@ const { parseArgs } = require('../index.js');
 test('when short option used as flag then stored as flag', function(t) {
   const passedArgs = ['-f'];
   const expected = { flags: { f: true }, values: { f: undefined }, positionals: [] };
-  const args = parseArgs({ argv: passedArgs });
+  const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected);
 
@@ -19,7 +19,7 @@ test('when short option used as flag then stored as flag', function(t) {
 test('when short option used as flag before positional then stored as flag and positional (and not value)', function(t) {
   const passedArgs = ['-f', 'bar'];
   const expected = { flags: { f: true }, values: { f: undefined }, positionals: [ 'bar' ] };
-  const args = parseArgs({ argv: passedArgs });
+  const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected);
 
@@ -30,7 +30,7 @@ test('when short option `type: "string"` used with value then stored as value', 
   const passedArgs = ['-f', 'bar'];
   const passedOptions = { f: { type: 'string' } };
   const expected = { flags: { f: true }, values: { f: 'bar' }, positionals: [] };
-  const args = parseArgs({ argv: passedArgs, options: passedOptions });
+  const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected);
 
@@ -41,7 +41,7 @@ test('when short option listed in short used as flag then long option stored as 
   const passedArgs = ['-f'];
   const passedOptions = { foo: { short: 'f' } };
   const expected = { flags: { foo: true }, values: { foo: undefined }, positionals: [] };
-  const args = parseArgs({ argv: passedArgs, options: passedOptions });
+  const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected);
 
@@ -52,7 +52,7 @@ test('when short option listed in short and long listed in `type: "string"` and 
   const passedArgs = ['-f', 'bar'];
   const passedOptions = { foo: { short: 'f', type: 'string' } };
   const expected = { flags: { foo: true }, values: { foo: 'bar' }, positionals: [] };
-  const args = parseArgs({ argv: passedArgs, options: passedOptions });
+  const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected);
 
@@ -63,7 +63,7 @@ test('when short option `type: "string"` used without value then stored as flag'
   const passedArgs = ['-f'];
   const passedOptions = { f: { type: 'string' } };
   const expected = { flags: { f: true }, values: { f: undefined }, positionals: [] };
-  const args = parseArgs({ argv: passedArgs, options: passedOptions });
+  const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected);
 
@@ -74,7 +74,7 @@ test('short option group behaves like multiple short options', function(t) {
   const passedArgs = ['-rf'];
   const passedOptions = { };
   const expected = { flags: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: [] };
-  const args = parseArgs({ argv: passedArgs, options: passedOptions });
+  const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected);
 
@@ -85,7 +85,7 @@ test('short option group does not consume subsequent positional', function(t) {
   const passedArgs = ['-rf', 'foo'];
   const passedOptions = { };
   const expected = { flags: { r: true, f: true }, values: { r: undefined, f: undefined }, positionals: ['foo'] };
-  const args = parseArgs({ argv: passedArgs, options: passedOptions });
+  const args = parseArgs({ args: passedArgs, options: passedOptions });
   t.deepEqual(args, expected);
 
   t.end();
@@ -96,7 +96,7 @@ test('if terminal of short-option group configured `type: "string"`, subsequent 
   const passedArgs = ['-rvf', 'foo'];
   const passedOptions = { f: { type: 'string' } };
   const expected = { flags: { r: true, f: true, v: true }, values: { r: undefined, v: undefined, f: 'foo' }, positionals: [] };
-  const args = parseArgs({ argv: passedArgs, options: passedOptions });
+  const args = parseArgs({ args: passedArgs, options: passedOptions });
   t.deepEqual(args, expected);
 
   t.end();
@@ -106,7 +106,7 @@ test('handles short-option groups in conjunction with long-options', function(t)
   const passedArgs = ['-rf', '--foo', 'foo'];
   const passedOptions = { foo: { type: 'string' } };
   const expected = { flags: { r: true, f: true, foo: true }, values: { r: undefined, f: undefined, foo: 'foo' }, positionals: [] };
-  const args = parseArgs({ argv: passedArgs, options: passedOptions });
+  const args = parseArgs({ args: passedArgs, options: passedOptions });
   t.deepEqual(args, expected);
 
   t.end();
@@ -116,7 +116,7 @@ test('handles short-option groups with "short" alias configured', function(t) {
   const passedArgs = ['-rf'];
   const passedOptions = { remove: { short: 'r' } };
   const expected = { flags: { remove: true, f: true }, values: { remove: undefined, f: undefined }, positionals: [] };
-  const args = parseArgs({ argv: passedArgs, options: passedOptions });
+  const args = parseArgs({ args: passedArgs, options: passedOptions });
   t.deepEqual(args, expected);
 
   t.end();
@@ -125,7 +125,7 @@ test('handles short-option groups with "short" alias configured', function(t) {
 test('Everything after a bare `--` is considered a positional argument', function(t) {
   const passedArgs = ['--', 'barepositionals', 'mopositionals'];
   const expected = { flags: {}, values: {}, positionals: ['barepositionals', 'mopositionals'] };
-  const args = parseArgs({ argv: passedArgs });
+  const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected, 'testing bare positionals');
 
@@ -135,7 +135,7 @@ test('Everything after a bare `--` is considered a positional argument', functio
 test('args are true', function(t) {
   const passedArgs = ['--foo', '--bar'];
   const expected = { flags: { foo: true, bar: true }, values: { foo: undefined, bar: undefined }, positionals: [] };
-  const args = parseArgs({ argv: passedArgs });
+  const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected, 'args are true');
 
@@ -145,7 +145,7 @@ test('args are true', function(t) {
 test('arg is true and positional is identified', function(t) {
   const passedArgs = ['--foo=a', '--foo', 'b'];
   const expected = { flags: { foo: true }, values: { foo: undefined }, positionals: ['b'] };
-  const args = parseArgs({ argv: passedArgs });
+  const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected, 'arg is true and positional is identified');
 
@@ -156,7 +156,7 @@ test('args equals are passed `type: "string"`', function(t) {
   const passedArgs = ['--so=wat'];
   const passedOptions = { so: { type: 'string' } };
   const expected = { flags: { so: true }, values: { so: 'wat' }, positionals: [] };
-  const args = parseArgs({ argv: passedArgs, options: passedOptions });
+  const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected, 'arg value is passed');
 
@@ -166,7 +166,7 @@ test('args equals are passed `type: "string"`', function(t) {
 test('when args include single dash then result stores dash as positional', function(t) {
   const passedArgs = ['-'];
   const expected = { flags: { }, values: { }, positionals: ['-'] };
-  const args = parseArgs({ argv: passedArgs });
+  const args = parseArgs({ args: passedArgs });
 
   t.deepEqual(args, expected);
 
@@ -177,7 +177,7 @@ test('zero config args equals are parsed as if `type: "string"`', function(t) {
   const passedArgs = ['--so=wat'];
   const passedOptions = { };
   const expected = { flags: { so: true }, values: { so: 'wat' }, positionals: [] };
-  const args = parseArgs({ argv: passedArgs, options: passedOptions });
+  const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected, 'arg value is passed');
 
@@ -188,7 +188,7 @@ test('same arg is passed twice `type: "string"` and last value is recorded', fun
   const passedArgs = ['--foo=a', '--foo', 'b'];
   const passedOptions = { foo: { type: 'string' } };
   const expected = { flags: { foo: true }, values: { foo: 'b' }, positionals: [] };
-  const args = parseArgs({ argv: passedArgs, options: passedOptions });
+  const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected, 'last arg value is passed');
 
@@ -199,7 +199,7 @@ test('args equals pass string including more equals', function(t) {
   const passedArgs = ['--so=wat=bing'];
   const passedOptions = { so: { type: 'string' } };
   const expected = { flags: { so: true }, values: { so: 'wat=bing' }, positionals: [] };
-  const args = parseArgs({ argv: passedArgs, options: passedOptions });
+  const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected, 'arg value is passed');
 
@@ -210,7 +210,7 @@ test('first arg passed for `type: "string"` and "multiples" is in array', functi
   const passedArgs = ['--foo=a'];
   const passedOptions = { foo: { type: 'string', multiples: true } };
   const expected = { flags: { foo: true }, values: { foo: ['a'] }, positionals: [] };
-  const args = parseArgs({ argv: passedArgs, options: passedOptions });
+  const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected, 'first multiple in array');
 
@@ -226,7 +226,7 @@ test('args are passed `type: "string"` and "multiples"', function(t) {
     },
   };
   const expected = { flags: { foo: true }, values: { foo: ['a', 'b'] }, positionals: [] };
-  const args = parseArgs({ argv: passedArgs, options: passedOptions });
+  const args = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(args, expected, 'both arg values are passed');
 
@@ -239,8 +239,8 @@ test('order of option and positional does not matter (per README)', function(t) 
   const passedOptions = { foo: { type: 'string' } };
   const expected = { flags: { foo: true }, values: { foo: 'bar' }, positionals: ['baz'] };
 
-  t.deepEqual(parseArgs({ argv: passedArgs1, options: passedOptions }), expected, 'option then positional');
-  t.deepEqual(parseArgs({ argv: passedArgs2, options: passedOptions }), expected, 'positional then option');
+  t.deepEqual(parseArgs({ args: passedArgs1, options: passedOptions }), expected, 'option then positional');
+  t.deepEqual(parseArgs({ args: passedArgs2, options: passedOptions }), expected, 'positional then option');
 
   t.end();
 });
@@ -339,7 +339,7 @@ test('excess leading dashes on options are retained', function(t) {
     values: { '-triple': undefined },
     positionals: []
   };
-  const result = parseArgs({ argv: passedArgs, options: passedOptions });
+  const result = parseArgs({ args: passedArgs, options: passedOptions });
 
   t.deepEqual(result, expected, 'excess option dashes are retained');
 
@@ -352,7 +352,7 @@ test('invalid argument passed for options', function(t) {
   const passedArgs = ['--so=wat'];
   const passedOptions = 'bad value';
 
-  t.throws(function() { parseArgs({ argv: passedArgs, options: passedOptions }); }, {
+  t.throws(function() { parseArgs({ args: passedArgs, options: passedOptions }); }, {
     code: 'ERR_INVALID_ARG_TYPE'
   });
 
@@ -363,7 +363,7 @@ test('boolean passed to "type" option', function(t) {
   const passedArgs = ['--so=wat'];
   const passedOptions = { foo: { type: true } };
 
-  t.throws(function() { parseArgs({ argv: passedArgs, options: passedOptions }); }, {
+  t.throws(function() { parseArgs({ args: passedArgs, options: passedOptions }); }, {
     code: 'ERR_INVALID_ARG_TYPE'
   });
 
@@ -374,7 +374,7 @@ test('invalid union value passed to "type" option', function(t) {
   const passedArgs = ['--so=wat'];
   const passedOptions = { foo: { type: 'str' } };
 
-  t.throws(function() { parseArgs({ argv: passedArgs, options: passedOptions }); }, {
+  t.throws(function() { parseArgs({ args: passedArgs, options: passedOptions }); }, {
     code: 'ERR_INVALID_ARG_TYPE'
   });
 


### PR DESCRIPTION
Rename `argv` to `args` to reflect more neutral meaning and usage, as suggested in https://github.com/pkgjs/parseargs/pull/63